### PR TITLE
Added TLS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-/settings.ini
+settings.ini
+.idea/*
+ca.pem
+ldap.key
+ldap.pem
+

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -8,6 +8,12 @@ use_ssl = true
 base = ou=People,dc=example,dc=org
 search_filter = uid={uid}
 
+# Uncomment if your ldap server requires client to present those files
+#[tls]
+#key_file = ldap.key
+#cert_file = ldap.pem
+#ca_file = ca.pem
+
 # Uncomment for AD / Samba 4
 #type = ad
 #ad_domain = ad.example.org


### PR DESCRIPTION
In some ldap server implementation, it is possible that server requires client,
to provide key and certificate in order to allow communication.

Otherwise bind will fail with message: "Handshake Failure", "TLS communication error", or similar.
Depending which log you are looking at.

If server uses such configuration, then client machine has to create .ldaprc or ldaprc file in ~/
file will have:
	TLS_CACERT  /etc/ssl/ca.pem
	TLS_CERT    /etc/ssl/ldap.pem
	TLS_KEY     /etc/ssl/ldap.key

Tools like ldapsearch, ldappasswd etc. rely on this file to get certs location.

Any tool that wants to communicate with this type of ldap server, should either read .ldaprc file,
or have configuration of its own that specifies certs

This commit added section in settings.ini.example file,
that allows user to explixitely point to cert files.

Added a function construct_tls(), that will construct ldap3.Tls object
this function returns a valid Tls object if there is tls configuration defined in settings.ini file.
or returns None, if configuration is not defined.

Modified connect_ldap() function to work with Tls object.