### PR TITLE
Non-anonymous bind

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,7 +64,13 @@ def connect_ldap(conf, **kwargs):
                     use_ssl=conf.getboolean('use_ssl', False),
                     connect_timeout=5)
 
-    return Connection(server, raise_exceptions=True, **kwargs)
+    # Override connection credentials if bind_* variables are specified
+    tmp_kwargs = dict(kwargs)
+    if "bind_user" in conf and "bind_password" in conf and "user" in kwargs and 'password' in kwargs:
+        tmp_kwargs["user"] = conf["bind_user"]
+        tmp_kwargs["password"] = conf["bind_password"]
+
+    return Connection(server, raise_exceptions=True, **tmp_kwargs)
 
 
 def change_passwords(username, old_pass, new_pass):


### PR DESCRIPTION
I am using AD (Samba 4 actually) controlled by MS Admin interface which I am using for setting up user accounts. By doing that, users get their account  in the way they must change their password on the first login. Subsequently, this tool is return error 773, i.e., user can not change their password.

Dont know what is the best approach avoid this situation, I realized that providing bind credentials will be sufficient, so here it going. 

if bind_* variables are set LDAP login credentials get override.

Should be fixing #22 